### PR TITLE
Bump less to 1.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "node_modules/.bin/mocha --require test/common.js"
   },
   "dependencies": {
-    "less": "1.3.x",
+    "less": "1.4.x",
     "progeny": "~0.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Any reason not to upgrade the plugin to 1.4.x?
