### PR TITLE
Allow arbitrary options to be passed to the less compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,23 @@ Adds [LESS](http://lesscss.org/) support to
 
 ### Options
 Print source-file references in output by setting `dumpLineNumbers` in your
-`brunch-config`:
+`brunch-config` (only available when `optimize` option is disabled):
 
 ```coffee
   plugins:
     less:
       dumpLineNumbers: 'comments' # other options: 'mediaquery', 'all'
+```
+
+Set or override global variables using `globalVars` and `modifyVars` respectively.
+
+```coffee
+  plugins:
+    less:
+      globalVars:
+        requiredColor: '#abcdef'
+      modifyVars: {
+        overridableColor: '#123456'
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -1,15 +1,16 @@
 var less = require('less');
 var sysPath = require('path');
 var progeny = require('progeny');
+var _ = require('underscore');
 
 function LESSCompiler(config) {
   if (config == null) config = {};
   if (config.plugins == null) config.plugins = {};
 
-  this.config = config.plugins.less || {};
+  this.options = _.extend({}, config.plugins.less);
   this.rootPath = config.paths.root;
   if (config.optimize) {
-    this.config.dumpLineNumbers = false;
+    this.options.dumpLineNumbers = false;
   }
   this.getDependencies = progeny({rootPath: this.rootPath, reverseArgs: true});
 }
@@ -22,9 +23,11 @@ LESSCompiler.prototype.compile = function(params, callback) {
   var data = params.data;
   var path = params.path;
 
-  this.config.paths = [this.rootPath, sysPath.dirname(path)];
-  this.config.filename = path;
-  less.render(data, this.config, function(error, output) {
+  var options = _.extend({}, this.options, {
+    paths: [this.rootPath, sysPath.dirname(path)],
+    filename: path
+  });
+  less.render(data, options, function(error, output) {
     if (error != null) {
       var err;
       err = '' + error.type + 'Error:' + error.message;

--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ function LESSCompiler(config) {
 
   this.config = config.plugins.less || {};
   this.rootPath = config.paths.root;
-  this.optimize = config.optimize;
+  if (config.optimize) {
+    this.config.dumpLineNumbers = false;
+  }
   this.getDependencies = progeny({rootPath: this.rootPath, reverseArgs: true});
 }
 
@@ -20,11 +22,9 @@ LESSCompiler.prototype.compile = function(params, callback) {
   var data = params.data;
   var path = params.path;
 
-  less.render(data, {
-    paths: [this.rootPath, sysPath.dirname(path)],
-    filename: path,
-    dumpLineNumbers: !this.optimize && this.config.dumpLineNumbers
-  }, function(error, output) {
+  this.config.paths = [this.rootPath, sysPath.dirname(path)];
+  this.config.filename = path;
+  less.render(data, this.config, function(error, output) {
     if (error != null) {
       var err;
       err = '' + error.type + 'Error:' + error.message;

--- a/index.js
+++ b/index.js
@@ -1,17 +1,17 @@
 var less = require('less');
 var sysPath = require('path');
 var progeny = require('progeny');
-var _ = require('underscore');
+var extend = require('util-extend');
 
 function LESSCompiler(config) {
   if (config == null) config = {};
   if (config.plugins == null) config.plugins = {};
 
-  this.options = _.extend({}, config.plugins.less);
-  this.rootPath = config.paths.root;
+  this.options = extend({}, config.plugins.less);
   if (config.optimize) {
     this.options.dumpLineNumbers = false;
   }
+  this.rootPath = config.paths.root;
   this.getDependencies = progeny({rootPath: this.rootPath, reverseArgs: true});
 }
 
@@ -23,10 +23,9 @@ LESSCompiler.prototype.compile = function(params, callback) {
   var data = params.data;
   var path = params.path;
 
-  var options = _.extend({}, this.options, {
-    paths: [this.rootPath, sysPath.dirname(path)],
-    filename: path
-  });
+  var options = extend({}, this.options);
+  options.paths = [this.rootPath, sysPath.dirname(path)];
+  options.filename = path;
   less.render(data, options, function(error, output) {
     if (error != null) {
       var err;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "less": "^2.2.0",
     "progeny": "^0.5.0",
-    "underscore": "^1.7.0"
+    "util-extend": "^1.0.1"
   },
   "devDependencies": {
     "mocha": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "less": "^2.2.0",
-    "progeny": "^0.5.0"
+    "progeny": "^0.5.0",
+    "underscore": "^1.7.0"
   },
   "devDependencies": {
     "mocha": "^2.1.0",

--- a/test.js
+++ b/test.js
@@ -5,7 +5,19 @@ describe('Plugin', function() {
   var plugin;
 
   beforeEach(function() {
-    plugin = new Plugin({paths: {root: '.'}});
+    plugin = new Plugin({
+      paths: {root: '.'},
+      plugins: {
+        less: {
+          globalVars: {
+            requiredColor: '#abcdef'
+          },
+          modifyVars: {
+            overridableColor: '#123456'
+          }
+        }
+      }
+    });
   });
 
   it('should be an object', function() {
@@ -27,9 +39,31 @@ describe('Plugin', function() {
     });
   });
 
+  it('should allow `globalVars` to be passed in via plugins config', function(done) {
+    var content = '#header {color: @requiredColor;}';
+    var expected = '#header {\n  color: #abcdef;\n}\n';
+
+    plugin.compile({data: content, path: 'style.less'}, function(error, result) {
+      expect(error).not.to.be.ok;
+      expect(result.data).to.equal(expected)
+      done();
+    });
+  });
+
+  it('should allow `modifyVars` to be passed in via plugins config', function(done) {
+    var content = '@overridableColor: #4D926F; #header {color: @overridableColor;}';
+    var expected = '#header {\n  color: #123456;\n}\n';
+
+    plugin.compile({data: content, path: 'style.less'}, function(error, result) {
+      expect(error).not.to.be.ok;
+      expect(result.data).to.equal(expected)
+      done();
+    });
+  });
+
   it('should handle invalid less gracefully', function(done) {
     var content = '#header {color: @color;}';
-    var expected = 'NameError:variable @color is undefined in "style.less:1:16"';
+    var expected = 'NameError:variable @color is undefined in "style.less:2:16"';
 
     plugin.compile({data: content, path: 'style.less'}, function(error, result) {
       expect(error).to.be.ok;


### PR DESCRIPTION
This change passes all data in `plugins.less` to the less compiler, with the exception of current limitations. The immediate need is to allow passing `globalVars` and `modifyVars`.

See https://github.com/brunch/less-brunch/issues/17
