### PR TITLE
Add support for plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ class LESSCompiler {
       less.render(data, {
         paths: [this.rootPath, sysPath.dirname(path)],
         filename: path,
+        plugins: this.config.plugins,
         dumpLineNumbers: !this.optimize && this.config.dumpLineNumbers
       }, (error, output) => {
         //console.log(error, output);


### PR DESCRIPTION
Add the ability to use Less plugins from `brunch-config.js`:

```javascript
var LessPluginCleanCSS = require('less-plugin-clean-css');
var cleanCSSPlugin = new LessPluginCleanCSS({advanced: true});

...

plugins: {
  less: {
    plugins: [cleanCSSPlugin]
  }
}
```