### PR TITLE
files embedded with data-uri(path) are now identified as dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,19 @@ class LESSCompiler {
     this.config = config && config.plugins && config.plugins.less || {};
     this.rootPath = config.paths.root;
     this.optimize = config.optimize;
-    this.getDependencies = progeny({rootPath: this.rootPath, reverseArgs: true});
+  }
+
+  getDependencies(sourceContents, file, callback) {
+    progeny({rootPath: this.rootPath})(file, sourceContents, (err, deps) => {
+      if (!err) {
+        const re = /data-uri\s*\(\s*("|'|)([^)]*)\1\s*\)/g;
+        let match;
+        while (match = re.exec(sourceContents)) {
+          deps.push(sysPath.join(sysPath.dirname(file), match[2]));
+        }
+      }
+      callback(err, deps);
+    });
   }
 
   compile(params) {

--- a/test-files/test-dependency-resolution.less
+++ b/test-files/test-dependency-resolution.less
@@ -1,0 +1,5 @@
+@import "test-include.less";
+
+.foo{
+    background: data-uri("img/foo.jpg");
+}

--- a/test-files/test-include.less
+++ b/test-files/test-include.less
@@ -1,0 +1,4 @@
+
+.bar{
+    background: data-uri("img/bar.jpg");
+}

--- a/test.js
+++ b/test.js
@@ -1,3 +1,5 @@
+var fs = require('fs');
+var path = require('path');
 var expect = require('chai').expect;
 var Plugin = require('./');
 
@@ -32,6 +34,18 @@ describe('Plugin', function() {
 
     plugin.compile({data: content, path: 'style.less'}).then(null, error => {
       expect(error).to.equal(expected);
+      done();
+    });
+  });
+
+  it('should correctly identify stylesheet and data-uri dependencies', function(done) {
+    var file = 'test-files/test-dependency-resolution.less';
+    var content = fs.readFileSync(path.join(__dirname, file));
+
+
+    plugin.getDependencies(content, file, (error, deps) => {
+      expect(error).to.be.null();
+      expect(deps).to.eql(['test-files/test-include.less', 'test-files/img/foo.jpg']);
       done();
     });
   });


### PR DESCRIPTION
Previously, when using auto-reload-brunch in --watch mode, altering an embedded file didn't cause the stylesheet to refresh. This PR fixes that and adds a test case.