### PR TITLE
Allow passing arbitrary configuration to lessc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ Adds [LESS](http://lesscss.org/) support to
 `npm install --save less-brunch`
 
 ### Options
-Print source-file references in output by setting `dumpLineNumbers` in your
-`brunch-config`:
+Pass options as per [lessc's documentation](http://lesscss.org/usage/index.html) in your `brunch-config`,
+e.g. print source-file references in output by setting `dumpLineNumbers`.
 
 ```coffee
   plugins:
     less:
       dumpLineNumbers: 'comments' # other options: 'mediaquery', 'all'
 ```
+Note that some options are overwritten: `paths` and `filename` are set by the plugin.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ e.g. print source-file references in output by setting `dumpLineNumbers`.
       dumpLineNumbers: 'comments' # other options: 'mediaquery', 'all'
 ```
 Note that some options are overwritten: `paths` and `filename` are set by the plugin.
+In production mode line numbers are suppressed.
 
 
 ## License

--- a/index.js
+++ b/index.js
@@ -30,9 +30,9 @@ class LESSCompiler {
     const path = params.path;
     const config = Object.assign({}, this.config, {
       paths: [this.rootPath, sysPath.dirname(path)],
-      filename: path,
+      filename: path
     });
-    
+
     return new Promise((resolve, reject) => {
       less.render(data, config, (error, output) => {
         //console.log(error, output);

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ class LESSCompiler {
 
     this.config = config && config.plugins && config.plugins.less || {};
     this.rootPath = config.paths.root;
-    this.optimize = config.optimize;
   }
 
   getDependencies(sourceContents, file, callback) {
@@ -29,14 +28,13 @@ class LESSCompiler {
   compile(params) {
     const data = params.data;
     const path = params.path;
-
+    const config = Object.assign({}, this.config, {
+      paths: [this.rootPath, sysPath.dirname(path)],
+      filename: path,
+    });
+    
     return new Promise((resolve, reject) => {
-      less.render(data, {
-        paths: [this.rootPath, sysPath.dirname(path)],
-        filename: path,
-        plugins: this.config.plugins,
-        dumpLineNumbers: !this.optimize && this.config.dumpLineNumbers
-      }, (error, output) => {
+      less.render(data, config, (error, output) => {
         //console.log(error, output);
         if (error) {
           let err;

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ class LESSCompiler {
 
     this.config = config && config.plugins && config.plugins.less || {};
     this.rootPath = config.paths.root;
+    this.optimize = config.optimize;
   }
 
   getDependencies(sourceContents, file, callback) {
@@ -30,7 +31,8 @@ class LESSCompiler {
     const path = params.path;
     const config = Object.assign({}, this.config, {
       paths: [this.rootPath, sysPath.dirname(path)],
-      filename: path
+      filename: path,
+      dumpLineNumbers: !this.optimize && this.config.dumpLineNumbers
     });
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
There's an outdated pull request (#21) that was attempting to do this. Also solves #17. Since this is the day and age of `Object.assign` things can be done without external dependencies.

I also threw out the reference to `config.optimize` since it's not having any effect. The previous effect was that of preventing line-number comments which would get removed by clean-css anyways.

Example use case: I'm passing non-default options `strictMath: true` and `strictUnits: true` which have a direct effect on the compilation outcome but could not previously be passed through.