### PR TITLE
Node 7 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "Adds LESS support to brunch.",
   "author": "Paul Miller (http://paulmillr.com/)",
   "homepage": "https://github.com/brunch/less-brunch",
-  "keywords": ["brunchplugin", "less", "stylesheet"],
+  "keywords": [
+    "brunchplugin",
+    "less",
+    "stylesheet"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:brunch/less-brunch.git"
@@ -13,10 +17,10 @@
     "test": "eslint index.js && mocha"
   },
   "dependencies": {
-    "less": "~2.5.3",
-    "progeny": "~0.5.0",
+    "less": "~2.7.1",
     "postcss": "~5.0.19",
-    "postcss-modules": "~0.4.0"
+    "postcss-modules": "~0.4.0",
+    "progeny": "~0.5.0"
   },
   "devDependencies": {
     "mocha": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git@github.com:brunch/less-brunch.git"
   },
   "scripts": {
-    "test": "node_modules/.bin/eslint index.js && node_modules/.bin/mocha"
+    "test": "eslint index.js && mocha"
   },
   "dependencies": {
     "less": "~2.5.3",

--- a/test.js
+++ b/test.js
@@ -45,7 +45,10 @@ describe('Plugin', function() {
 
     plugin.getDependencies(content, file, (error, deps) => {
       expect(error).to.be.null();
-      expect(deps).to.eql(['test-files/test-include.less', 'test-files/img/foo.jpg']);
+      expect(deps).to.eql([
+        path.join('test-files', 'test-include.less'),
+        path.join('test-files', 'img', 'foo.jpg')
+      ]);
       done();
     });
   });

--- a/test.js
+++ b/test.js
@@ -1,24 +1,27 @@
+/* eslint-env mocha */
+/* eslint no-unused-expressions: off */
+
 var fs = require('fs');
 var path = require('path');
 var expect = require('chai').expect;
 var Plugin = require('./');
 
-describe('Plugin', function() {
+describe('Plugin', () => {
   var plugin;
 
-  beforeEach(function() {
+  beforeEach(() => {
     plugin = new Plugin({paths: {root: '.'}});
   });
 
-  it('should be an object', function() {
+  it('should be an object', () => {
     expect(plugin).to.be.ok;
   });
 
-  it('should has #compile method', function() {
+  it('should has #compile method', () => {
     expect(plugin.compile).to.be.an.instanceof(Function);
   });
 
-  it('should compile and produce valid result', function(done) {
+  it('should compile and produce valid result', (done) => {
     var content = '@color: #4D926F; #header {color: @color;}';
     var expected = '#header {\n  color: #4D926F;\n}\n';
 
@@ -28,7 +31,7 @@ describe('Plugin', function() {
     }, error => expect(error).not.to.be.ok);
   });
 
-  it('should handle invalid less gracefully', function(done) {
+  it('should handle invalid less gracefully', (done) => {
     var content = '#header {color: @color;}';
     var expected = 'NameError:variable @color is undefined in "style.less:1:16"';
 
@@ -38,7 +41,7 @@ describe('Plugin', function() {
     });
   });
 
-  it('should correctly identify stylesheet and data-uri dependencies', function(done) {
+  it('should correctly identify stylesheet and data-uri dependencies', (done) => {
     var file = 'test-files/test-dependency-resolution.less';
     var content = fs.readFileSync(path.join(__dirname, file));
 


### PR DESCRIPTION
Only the last commit is actually about Node 7 compatibility. It updates `less` to 2.7.1, which depends on a version of `graceful-fs` that will work on Node 7. See https://github.com/isaacs/node-graceful-fs/issues/64.

The first 3 commits are slight tweaks to make `npm test` work on my environment. I think it's useful, but if there is anything bothering you in there, let me know and I'll remove it. The point is to make `less-brunch` work under Node 7.

Thanks for making brunch. :+1: 