### PR TITLE
Upgrade to LESS 3.9.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # less-brunch `<unreleased>`
 * Added support for CSS Modules with Brunch.
 * Added ability to pass any options to the less compiler.
+* Updated LESS to latest 3.9.x
+* Updated PostCSS to latest 7.0.x
 
 # less-brunch 2.0.0 (Jan 29, 2016)
 * Updated source code & API. The plugin would now only work with Brunch 2.2 and higher.

--- a/package.json
+++ b/package.json
@@ -17,16 +17,16 @@
     "test": "eslint index.js && mocha"
   },
   "dependencies": {
-    "less": "~2.7.1",
-    "postcss": "~5.0.19",
-    "postcss-modules": "~0.4.0",
-    "progeny": "~0.5.0"
+    "less": "~3.9.0",
+    "postcss": "~7.0.8",
+    "postcss-modules": "~1.4.1",
+    "progeny": "~0.12.0"
   },
   "devDependencies": {
     "chai": "^4.0",
-    "eslint": "^4.0",
-    "eslint-config-brunch": "^1.0",
-    "mocha": "^3.0"
+    "eslint": "^5.12.0",
+    "eslint-config-brunch": "^1.0.0",
+    "mocha": "^5.2.0"
   },
   "eslintConfig": {
     "extends": "brunch"


### PR DESCRIPTION
LESS 3 has been around for a bit, and there are very few breaking API changes. Using LESS 3 doesn't seem to break anything: the tests pass; we've been using this version without any issues.